### PR TITLE
Tweaks package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,17 @@
 {
   "name": "availability-app",
+  "private": true,
   "version": "1.0.0",
-  "description": "An app to keep track of employee's availability",
-  "main": "server.js",
+  "description": "An app to keep track of employees' availability",
+  "author": "Joshua Zuo <neveragain8209@yahoo.com>",
+  "license": "ISC",
+  "main": "api/server.js",
   "scripts": {
+    "start": "npm run api:start",
     "api:start": "node api/server.js",
     "api:watch": "nodemon api/server.js",
     "test": "mocha --exit"
   },
-  "author": "Joshua Zuo",
-  "license": "ISC",
   "dependencies": {
     "bcrypt": "^2.0.1",
     "dotenv": "^6.0.0",


### PR DESCRIPTION
- Set the package as private (avoids publishing package on public registries)
- Adds a command for `npm start` (calls `api:start` to start the API)
- Moves metadata to the top (helps keeping scripts and dependencies together)
- Adds author's email to the `author` key (licensing purposes)